### PR TITLE
Upgrade jetty version for something happened in Java 8 Update 91(or later) that broke existing JSP code.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,6 +60,12 @@
       <version>2.4.3</version>
     </dependency>
 
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-server</artifactId>
+      <version>8.1.9.v20130131</version>
+    </dependency>
+
   </dependencies>
 
   <build>
@@ -78,7 +84,7 @@
         <groupId>org.mortbay.jetty</groupId>
         <artifactId>jetty-maven-plugin</artifactId>
         <!-- Plugin version == server version -->
-        <version>7.5.1.v20110908</version>
+        <version>8.1.9.v20130131</version>
         <configuration>
           <scanIntervalSeconds>0</scanIntervalSeconds>
           <jettyConfig>${basedir}/src/etc/jetty.xml</jettyConfig>

--- a/src/main/resources/parts/mdc_turbo_filter.xml
+++ b/src/main/resources/parts/mdc_turbo_filter.xml
@@ -1,5 +1,5 @@
 	<turboFilter class="ch.qos.logback.classic.turbo.MDCFilter">
-		<MDCKey>username</MDCKey>
+		<MDCKey>userid</MDCKey>
 		<Value>sebastien</Value>
 		<OnMatch>ACCEPT</OnMatch>
 	</turboFilter>


### PR DESCRIPTION
fix the bug below:
The type java.io.ObjectInputStream cannot be resolved. It is indirectly referenced from required .class files.